### PR TITLE
Add tooltip and alert for pololo preference

### DIFF
--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -1,6 +1,7 @@
 import { Question, QuestionOption } from "@/data/questions";
 import { KawaiiButton } from "./KawaiiButton";
 import { Card } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface QuestionCardProps {
   question: Question;
@@ -16,19 +17,41 @@ export const QuestionCard = ({ question, selectedOption, onOptionSelect }: Quest
       </h2>
       
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {question.options.map((option: QuestionOption) => (
-          <KawaiiButton
-            key={option.id}
-            variant="kawaii"
-            size="lg"
-            isSelected={selectedOption === option.id}
-            onClick={() => onOptionSelect(option.id)}
-            className="h-auto py-4 flex flex-col items-center gap-2"
-          >
-            <span className="text-3xl">{option.emoji}</span>
-            <span className="text-sm font-medium">{option.text}</span>
-          </KawaiiButton>
-        ))}
+        {question.options.map((option: QuestionOption) => {
+          if (question.id === "pololo-preference" && option.id === "nada") {
+            return (
+              <Tooltip key={option.id}>
+                <TooltipTrigger asChild>
+                  <KawaiiButton
+                    variant="kawaii"
+                    size="lg"
+                    isSelected={selectedOption === option.id}
+                    onClick={() => onOptionSelect(option.id)}
+                    className="h-auto py-4 flex flex-col items-center gap-2"
+                  >
+                    <span className="text-3xl">{option.emoji}</span>
+                    <span className="text-sm font-medium">{option.text}</span>
+                  </KawaiiButton>
+                </TooltipTrigger>
+                <TooltipContent>OJO &gt;:(</TooltipContent>
+              </Tooltip>
+            );
+          }
+
+          return (
+            <KawaiiButton
+              key={option.id}
+              variant="kawaii"
+              size="lg"
+              isSelected={selectedOption === option.id}
+              onClick={() => onOptionSelect(option.id)}
+              className="h-auto py-4 flex flex-col items-center gap-2"
+            >
+              <span className="text-3xl">{option.emoji}</span>
+              <span className="text-sm font-medium">{option.text}</span>
+            </KawaiiButton>
+          );
+        })}
       </div>
     </Card>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -40,13 +40,16 @@ const Index = () => {
 
   const handleOptionSelect = (optionId: string) => {
     const newSelectedOptions = [...selectedOptions];
-    
+
     if (currentQuestionIndex === 0) {
       newSelectedOptions[0] = optionId;
       setSelectedOptions(newSelectedOptions);
       setCurrentQuestionIndex(1);
       setCurrentState('question-pololo');
     } else if (currentQuestionIndex === 1) {
+      if (optionId === 'nada') {
+        alert('Haz matado a un pudú :(');
+      }
       newSelectedOptions[1] = optionId;
       setSelectedOptions(newSelectedOptions);
       setCurrentQuestionIndex(2);


### PR DESCRIPTION
## Summary
- warn users on hover over “Nada :(” option with tooltip "OJO >:("
- alert "Haz matado a un pudú :(" when selecting that option during the pololo question

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: `@typescript-eslint/no-empty-object-type` and `@typescript-eslint/no-require-imports` errors)


------
https://chatgpt.com/codex/tasks/task_e_68923b16af3483299ecb5d9e29ecbe64