### PR TITLE
feat: expand assisted mode questions

### DIFF
--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -359,12 +359,108 @@ export const getTodaysQuestion = (): Question => {
   return dailyQuestions[today % dailyQuestions.length];
 };
 
+// Questions for the assisted mode flow (pololo question + extra questions)
+export const assistedQuestions: Question[] = [
+  dailyQuestions[1],
+  {
+    id: 'aventura',
+    text: '¿Qué aventura culinaria te hace ojitos hoy? (｡◕‿◕｡)',
+    options: [
+      {
+        id: 'abrazo-casero',
+        text: 'Abracito casero (calorcito + cariñito) 🧣',
+        emoji: '🧣',
+        categories: ['chilena-tradicional', 'picadas', 'italiana', 'espanola']
+      },
+      {
+        id: 'costa-citrico',
+        text: 'Brisa de mar con limoncito 🍋🌊',
+        emoji: '🌊',
+        categories: ['marisqueria', 'peruana', 'nikkei']
+      },
+      {
+        id: 'fuego-humo',
+        text: 'Modo dragóncito 🔥 (ahumado rico)',
+        emoji: '🔥',
+        categories: ['parrilla', 'americana', 'brasilena', 'alemana']
+      },
+      {
+        id: 'tour-asia',
+        text: 'Pasaporte a Asia ✈️🍜',
+        emoji: '🧭',
+        categories: ['china', 'japonesa', 'coreana', 'tailandesa', 'india']
+      },
+      {
+        id: 'calle-antojo',
+        text: 'Paseíto callejero (ñam express) 🚶',
+        emoji: '🚶',
+        categories: ['sanguches', 'completos', 'mexicana', 'venezolana', 'turca', 'arabe', 'pizzeria']
+      },
+      {
+        id: 'dulce-brunch',
+        text: 'Dulcecito & brunchito (mimi break) 🍰',
+        emoji: '🍰',
+        categories: ['pasteleria', 'brunch', 'saludable', 'veggie']
+      }
+    ]
+  },
+  {
+    id: 'formato',
+    text: '¿Cómo quieren vivir este antojito hoy? ✨',
+    options: [
+      {
+        id: 'rapido',
+        text: '¡Rápido-rápido! (tengo hambrita) ⏱️',
+        emoji: '⏱️',
+        categories: ['sanguches', 'completos', 'pizzeria', 'pasteleria']
+      },
+      {
+        id: 'compartir',
+        text: 'Para picotear juntitos 🧑‍🤝‍🧑',
+        emoji: '🧑‍🤝‍🧑',
+        categories: ['espanola', 'arabe', 'turca', 'coreana', 'mexicana']
+      },
+      {
+        id: 'manteles-largos',
+        text: 'Plan elegante (wow wow) ✨',
+        emoji: '✨',
+        categories: ['autor', 'francesa', 'nikkei', 'japonesa']
+      },
+      {
+        id: 'tenedor',
+        text: 'Plato apañador (tenedor poderoso) 🍽️',
+        emoji: '🍽️',
+        categories: ['chilena-tradicional', 'italiana', 'alemana', 'parrilla']
+      },
+      {
+        id: 'ligero',
+        text: 'Ligero & fresco (panza feliz) 🌿',
+        emoji: '🌿',
+        categories: ['saludable', 'veggie', 'peruana', 'marisqueria', 'nikkei']
+      }
+    ]
+  },
+  {
+    id: 'no-quiero',
+    text: 'Cuéntame un “no-no” de hoy 🙈 (opcional)',
+    options: [
+      { id: 'no-mariscos', text: 'Sin marisquitos hoy, porfi 🐟', emoji: '🐟', categories: [] },
+      { id: 'no-picante', text: 'Sin picantito, soy sensible 🌶️💧', emoji: '🌶️', categories: [] },
+      { id: 'no-carne-roja', text: 'Hoy sin carnita roja 🥩🚫', emoji: '🥩', categories: [] },
+      { id: 'no-frito', text: 'Evitemos lo muy frito 🍳', emoji: '🍳', categories: [] },
+      { id: 'no-lacteos', text: 'Sin lácteos (barriguita sensible) 🥛', emoji: '🥛', categories: [] },
+      { id: 'no-sopas', text: 'Nada muy caldoso hoy 🥣', emoji: '🥣', categories: [] },
+      { id: 'sin-restriccion', text: 'Todo vale, ¡sorpréndeme! ✨', emoji: '🙅', categories: [] }
+    ]
+  }
+];
+
 // Function to get random categories based on user selections
 export const getRecommendedCategories = (selectedOptions: string[]): FoodCategory[] => {
   const allCategories: string[] = [];
-  
+
   selectedOptions.forEach(optionId => {
-    dailyQuestions.forEach(question => {
+    assistedQuestions.forEach(question => {
       const option = question.options.find(opt => opt.id === optionId);
       if (option) {
         allCategories.push(...option.categories);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { KawaiiHeader } from "@/components/KawaiiHeader";
 import { QuestionCard } from "@/components/QuestionCard";
 import { CategoryCard } from "@/components/CategoryCard";
 import { KawaiiButton } from "@/components/KawaiiButton";
 import { KawaiiRuleta } from "@/components/KawaiiRuleta";
-import { getTodaysQuestion, getRecommendedCategories, dailyQuestions, FoodCategory } from "@/data/questions";
+import { assistedQuestions, getRecommendedCategories, FoodCategory } from "@/data/questions";
 import { RotateCcw, ChefHat, Dice6, Heart } from "lucide-react";
 
 type AppState = 'welcome' | 'mode-selection' | 'ruleta' | 'question' | 'results';
@@ -16,13 +16,6 @@ const Index = () => {
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [recommendedCategories, setRecommendedCategories] = useState<FoodCategory[]>([]);
-  const [todaysQuestion, setTodaysQuestion] = useState(getTodaysQuestion());
-  const assistedQuestions = [dailyQuestions[1], todaysQuestion, dailyQuestions[2]];
-
-  useEffect(() => {
-    // TODO: In a real app, this would update daily based on server time or stored date
-    setTodaysQuestion(getTodaysQuestion());
-  }, []);
 
   const handleStartApp = () => {
     setCurrentState('mode-selection');
@@ -70,10 +63,9 @@ const Index = () => {
     setSelectedOptions([]);
     setCurrentQuestionIndex(0);
     setRecommendedCategories([]);
-    setTodaysQuestion(getTodaysQuestion());
   };
 
-  const handleSkipThirdQuestion = () => {
+  const handleSkipLastQuestion = () => {
     const categories = getRecommendedCategories(selectedOptions.slice(0, currentQuestionIndex));
     setRecommendedCategories(categories);
     setCurrentState('results');
@@ -188,7 +180,7 @@ const Index = () => {
               <div className="space-x-4">
                 <KawaiiButton
                   variant="secondary"
-                  onClick={handleSkipThirdQuestion}
+                  onClick={handleSkipLastQuestion}
                 >
                   Omitir
                 </KawaiiButton>


### PR DESCRIPTION
## Summary
- add assisted mode questions for culinary adventure, format and optional exclusions
- load assisted questions in index page and handle optional last question

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: `@typescript-eslint/no-empty-object-type`, `@typescript-eslint/no-require-imports`)


------
https://chatgpt.com/codex/tasks/task_e_68925d5e0c888329ba83287643f8a61c