### PR TITLE
feat: add top category recommendation

### DIFF
--- a/src/lib/recommend.ts
+++ b/src/lib/recommend.ts
@@ -1,0 +1,104 @@
+import { assistedQuestions, foodCategories, FoodCategory } from "@/data/questions";
+
+export type CategoryId = (typeof foodCategories)[number]["id"];
+
+export const EXCLUDE_MAP: Record<string, CategoryId[]> = {
+  "no-mariscos": ["marisqueria", "peruana", "nikkei", "japonesa"],
+  "no-picante": ["mexicana", "tailandesa", "india", "coreana"],
+  "no-carne-roja": ["parrilla", "alemana", "brasilena", "americana"],
+  "no-frito": ["completos", "sanguches", "americana", "pizzeria", "venezolana"],
+  "no-sopas": ["chilena-tradicional", "marisqueria", "mapuche", "japonesa"],
+};
+
+// Extra weights for thematic boosts based on certain answers
+export const BOOSTS: Record<string, Partial<Record<CategoryId, number>>> = {
+  picante: { mexicana: 1, tailandesa: 1, india: 1, coreana: 1 },
+  comfort: { "chilena-tradicional": 1, picadas: 1, italiana: 1, americana: 1 },
+  aventurero: { nikkei: 1, autor: 1, tailandesa: 1, coreana: 1, mapuche: 1 },
+  saludable: { saludable: 1, veggie: 1, japonesa: 1, peruana: 1 },
+  celebrando: { parrilla: 1, marisqueria: 1, autor: 1, brasilena: 1, francesa: 1 },
+  dulce: { pasteleria: 1, brunch: 1 },
+  "costa-citrico": { marisqueria: 1, peruana: 1, nikkei: 1 },
+  "fuego-humo": { parrilla: 1, americana: 1, brasilena: 1, alemana: 1 },
+  "tour-asia": { china: 1, japonesa: 1, coreana: 1, tailandesa: 1, india: 1 },
+  "calle-antojo": {
+    sanguches: 1,
+    completos: 1,
+    mexicana: 1,
+    venezolana: 1,
+    turca: 1,
+    arabe: 1,
+    pizzeria: 1,
+  },
+  "dulce-brunch": { pasteleria: 1, brunch: 1, saludable: 0.5, veggie: 0.5 },
+  rapido: { sanguches: 1, completos: 1, pizzeria: 1, pasteleria: 1 },
+  compartir: { espanola: 1, arabe: 1, turca: 1, coreana: 1, mexicana: 1 },
+  "manteles-largos": { autor: 1, francesa: 1, nikkei: 1, japonesa: 1 },
+  tenedor: { "chilena-tradicional": 1, italiana: 1, alemana: 1, parrilla: 1 },
+  ligero: { saludable: 1, veggie: 1, peruana: 1, marisqueria: 1, nikkei: 1 },
+};
+
+const DAIRY_CATEGORIES: CategoryId[] = [
+  "italiana",
+  "pizzeria",
+  "pasteleria",
+  "brunch",
+  "francesa",
+];
+
+/**
+ * Recommend top 3 categories based on user selected options.
+ * Applies base scoring, thematic boosts, exclusions and a soft ban on dairy.
+ */
+export function recommendTop3(selectedOptions: string[]): FoodCategory[] {
+  const scores: Record<CategoryId, number> = {};
+  const excluded = new Set<CategoryId>();
+
+  selectedOptions.forEach((optionId) => {
+    // Base scores from question option categories
+    assistedQuestions.forEach((question) => {
+      const option = question.options.find((o) => o.id === optionId);
+      if (option) {
+        option.categories.forEach((cat) => {
+          const id = cat as CategoryId;
+          scores[id] = (scores[id] || 0) + 1;
+        });
+      }
+    });
+
+    // Apply thematic boosts
+    const boost = BOOSTS[optionId];
+    if (boost) {
+      Object.entries(boost).forEach(([cat, value]) => {
+        const id = cat as CategoryId;
+        scores[id] = (scores[id] || 0) + value!;
+      });
+    }
+
+    // Collect exclusions
+    const toExclude = EXCLUDE_MAP[optionId];
+    if (toExclude) {
+      toExclude.forEach((c) => excluded.add(c));
+    }
+  });
+
+  // Soft ban for dairy heavy categories
+  if (selectedOptions.includes("no-lacteos")) {
+    DAIRY_CATEGORIES.forEach((cat) => {
+      scores[cat] = (scores[cat] || 0) - 2; // Penalty instead of exclusion
+    });
+  }
+
+  // Build final sorted list excluding hard bans
+  const ranked = foodCategories
+    .filter((cat) => !excluded.has(cat.id as CategoryId))
+    .map((cat) => ({ cat, score: scores[cat.id as CategoryId] || 0 }))
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .map((item) => item.cat);
+
+  return ranked;
+}
+
+export default recommendTop3;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,7 +4,8 @@ import { QuestionCard } from "@/components/QuestionCard";
 import { CategoryCard } from "@/components/CategoryCard";
 import { KawaiiButton } from "@/components/KawaiiButton";
 import { KawaiiRuleta } from "@/components/KawaiiRuleta";
-import { assistedQuestions, getRecommendedCategories, FoodCategory } from "@/data/questions";
+import { assistedQuestions, FoodCategory } from "@/data/questions";
+import { recommendTop3 } from "@/lib/recommend";
 import { RotateCcw, ChefHat, Dice6, Heart } from "lucide-react";
 
 type AppState = 'welcome' | 'mode-selection' | 'ruleta' | 'question' | 'results';
@@ -46,7 +47,7 @@ const Index = () => {
     if (nextIndex < assistedQuestions.length) {
       setCurrentQuestionIndex(nextIndex);
     } else {
-      const categories = getRecommendedCategories(newSelectedOptions);
+      const categories = recommendTop3(newSelectedOptions);
       setRecommendedCategories(categories);
       setCurrentState('results');
     }
@@ -66,7 +67,7 @@ const Index = () => {
   };
 
   const handleSkipLastQuestion = () => {
-    const categories = getRecommendedCategories(selectedOptions.slice(0, currentQuestionIndex));
+    const categories = recommendTop3(selectedOptions.slice(0, currentQuestionIndex));
     setRecommendedCategories(categories);
     setCurrentState('results');
   };


### PR DESCRIPTION
## Summary
- expose recommendTop3 with scoring, boosts and exclusions
- use recommendTop3 in index screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden)*
- `npx eslint src/lib/recommend.ts src/pages/Index.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6892634c7b3c832993baaddda8c63a73