### PR TITLE
feat: add background music with play control

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { BackgroundMusic } from "@/components/BackgroundMusic";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
@@ -13,6 +14,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
+      <BackgroundMusic />
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />

--- a/src/components/BackgroundMusic.tsx
+++ b/src/components/BackgroundMusic.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react";
+import { Play, Pause } from "lucide-react";
+import { KawaiiButton } from "@/components/KawaiiButton";
+
+export const BackgroundMusic = () => {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(true);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const playPromise = audio.play();
+    if (playPromise !== undefined) {
+      playPromise.catch(() => setPlaying(false));
+    }
+  }, []);
+
+  const toggle = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (playing) {
+      audio.pause();
+      setPlaying(false);
+    } else {
+      audio.play();
+      setPlaying(true);
+    }
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4">
+      <audio ref={audioRef} src="/bg-music.mp3" loop autoPlay />
+      <KawaiiButton size="sm" onClick={toggle} aria-label={playing ? "Pausar música" : "Reproducir música"}>
+        {playing ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+      </KawaiiButton>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add BackgroundMusic component that auto-plays site bg music and offers play/pause button
- mount BackgroundMusic globally so tune persists across pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 3 errors, 7 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_689270d31b0c83298e7ad63c26f1a5a5