### PR TITLE
Add Spotify env configuration and docs

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+VITE_SPOTIFY_CLIENT_ID=<tu_client_id>
+VITE_SPOTIFY_REDIRECT_URI=<url_de_redirección>
+VITE_SPOTIFY_PLAYLIST_ID=<playlist_id_por_defecto>

--- a/README.md
+++ b/README.md
@@ -71,3 +71,11 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Credenciales de Spotify
+
+1. Visita el [Spotify Developer Dashboard](https://developer.spotify.com/dashboard).
+2. Inicia sesión con tu cuenta de Spotify y crea una aplicación.
+3. Dentro de la aplicación, copia el **Client ID** y añade la URL de redirección en la sección *Redirect URIs*.
+4. Guarda los cambios y usa esos valores para `VITE_SPOTIFY_CLIENT_ID` y `VITE_SPOTIFY_REDIRECT_URI` en el archivo `.env`.
+5. Para obtener un `playlist_id`, abre la playlist en Spotify, usa "Compartir > Copiar enlace" y extrae el identificador de la URL. Asigna este valor a `VITE_SPOTIFY_PLAYLIST_ID`.


### PR DESCRIPTION
## Summary
- add `.env` with Spotify environment variables
- document how to get Spotify credentials in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 3 errors, 7 warnings)

------
https://chatgpt.com/codex/tasks/task_e_6894bfebefc48329a5544f6f36f1ec38